### PR TITLE
Use ViaVersion to show leads when displaying TCC Track to different versions other than the server version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <project.serverversion>1.15.2-R0.1-SNAPSHOT</project.serverversion>
         <project.bkcversion>1.16.1-v1</project.bkcversion>
         <project.tcversion>1.16.1-v1</project.tcversion>
+        <project.viaversion>3.2.1</project.viaversion>
         <junit.version>4.12</junit.version>
     </properties>
 
@@ -67,6 +68,12 @@
             <id>sk89q</id>
             <url>http://maven.sk89q.com/repo/</url>
         </repository>
+        <!-- Viaversion -->
+        <repository>
+            <id>viaversion-repo</id>
+            <url>https://repo.viaversion.com</url>
+        </repository>
+
     </repositories>
 
     <dependencies>
@@ -108,6 +115,14 @@
             <groupId>com.plotsquared</groupId>
             <artifactId>PlotSquared-Core</artifactId>
             <version>5.12.0</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- ViaVersion API -->
+        <dependency>
+            <groupId>us.myles</groupId>
+            <artifactId>viaversion</artifactId>
+            <version>${project.viaversion}</version>
             <optional>true</optional>
         </dependency>
 

--- a/src/main/java/com/bergerkiller/bukkit/coasters/TCCoasters.java
+++ b/src/main/java/com/bergerkiller/bukkit/coasters/TCCoasters.java
@@ -99,7 +99,9 @@ public class TCCoasters extends PluginBase {
     private boolean plotSquaredEnabled = DEFAULT_PLOTSQUARED_ENABLED;
     private boolean lightAPIEnabled = DEFAULT_LIGHTAPI_ENABLED;
     private boolean lightAPIFound = false;
+    private boolean viaVersionEnabled = false;
     private Listener plotSquaredHandler = null;
+    private static Versioning versioning = new VersioningVanilla();
     private File importFolder, exportFolder;
 
     public void unloadWorld(World world) {
@@ -238,6 +240,12 @@ public class TCCoasters extends PluginBase {
     }
 
     /**
+     * Gets versioning class for correct
+     *
+     * @return Versioning variable, VersioningViaVersion if enabled
+     */
+    public static Versioning getVersioning() {return versioning;}
+    /**
      * Gets the particle view range. Players can see particles when
      * below this distance away from a particle.
      * 
@@ -318,6 +326,14 @@ public class TCCoasters extends PluginBase {
             }
         }
 
+        // Before loading, detect ViaVersion
+        {
+            Plugin plugin = Bukkit.getPluginManager().getPlugin("ViaVersion");
+            if (plugin != null && plugin.isEnabled()) {
+                this.updateDependency(plugin, plugin.getName(), true);
+            }
+        }
+
         // Load all coasters from csv
         for (World world : Bukkit.getWorlds()) {
             this.getCoasterWorld(world).getTracks().load();
@@ -389,6 +405,11 @@ public class TCCoasters extends PluginBase {
                 log(Level.INFO, "LightAPI disabled, the Light track object is no longer available");
                 TrackCSV.unregisterEntry(TrackObjectTypeLight.CSVEntry::new);
             }
+        } else if (pluginName.equals("ViaVersion") && enabled) {
+            log(Level.INFO, "ViaVersion detected, Will use player version info.");
+            this.viaVersionEnabled = true;
+            versioning = new VersioningViaVersion();
+
         }
     }
 

--- a/src/main/java/com/bergerkiller/bukkit/coasters/TCCoasters.java
+++ b/src/main/java/com/bergerkiller/bukkit/coasters/TCCoasters.java
@@ -101,7 +101,7 @@ public class TCCoasters extends PluginBase {
     private boolean lightAPIFound = false;
     private boolean viaVersionEnabled = false;
     private Listener plotSquaredHandler = null;
-    private static Versioning versioning = new VersioningVanilla();
+    private Versioning versioning = new VersioningVanilla();
     private File importFolder, exportFolder;
 
     public void unloadWorld(World world) {
@@ -244,7 +244,7 @@ public class TCCoasters extends PluginBase {
      *
      * @return Versioning variable, VersioningViaVersion if enabled
      */
-    public static Versioning getVersioning() {return versioning;}
+    public Versioning getVersioning() {return versioning;}
     /**
      * Gets the particle view range. Players can see particles when
      * below this distance away from a particle.

--- a/src/main/java/com/bergerkiller/bukkit/coasters/Versioning.java
+++ b/src/main/java/com/bergerkiller/bukkit/coasters/Versioning.java
@@ -1,6 +1,6 @@
 package com.bergerkiller.bukkit.coasters;
-        import com.bergerkiller.bukkit.common.internal.CommonBootstrap;
-        import org.bukkit.entity.Player;
+
+import org.bukkit.entity.Player;
 
 public interface Versioning {
 

--- a/src/main/java/com/bergerkiller/bukkit/coasters/Versioning.java
+++ b/src/main/java/com/bergerkiller/bukkit/coasters/Versioning.java
@@ -4,7 +4,24 @@ import org.bukkit.entity.Player;
 
 public interface Versioning {
 
+    /**
+     * Checks if the version is 1.16.2
+     * @param player Player to check (if using ViaVersion, ignores the variable if vanilla)
+     * @return If the version is 1.16.2 or above
+     */
     boolean SERVER_IS_1_16_2(Player player);
+
+    /**
+     * Checks if the version is 1.16 to 1.16.1
+     * @param player Player to check version, ignored if vanilla
+     * @return If the version is 1.16 to 1.16.1
+     */
     boolean SERVER_1_16_TO_1_16_1(Player player);
+
+    /**
+     * Checks if the version is 1.8 to 1.15.2
+     * @param player The Player to check
+     * @return If the version is 1.16 to 1.16.1
+     */
     boolean SERVER_IS_1_8_TO_1_15_2(Player player);
 }

--- a/src/main/java/com/bergerkiller/bukkit/coasters/Versioning.java
+++ b/src/main/java/com/bergerkiller/bukkit/coasters/Versioning.java
@@ -1,0 +1,10 @@
+package com.bergerkiller.bukkit.coasters;
+        import com.bergerkiller.bukkit.common.internal.CommonBootstrap;
+        import org.bukkit.entity.Player;
+
+public interface Versioning {
+
+    boolean SERVER_IS_1_16_2(Player player);
+    boolean SERVER_1_16_TO_1_16_1(Player player);
+    boolean SERVER_IS_1_8_TO_1_15_2(Player player);
+}

--- a/src/main/java/com/bergerkiller/bukkit/coasters/VersioningVanilla.java
+++ b/src/main/java/com/bergerkiller/bukkit/coasters/VersioningVanilla.java
@@ -1,0 +1,21 @@
+package com.bergerkiller.bukkit.coasters;
+import com.bergerkiller.bukkit.common.internal.CommonBootstrap;
+import org.bukkit.entity.Player;
+
+public class VersioningVanilla implements Versioning {
+
+    @Override
+    public boolean SERVER_IS_1_16_2(Player player) {
+        return CommonBootstrap.evaluateMCVersion(">=", "1.16.2");
+    }
+
+    @Override
+    public boolean SERVER_1_16_TO_1_16_1(Player player) {
+        return CommonBootstrap.evaluateMCVersion("<=", "1.16.1") && CommonBootstrap.evaluateMCVersion(">=", "1.16");
+    }
+
+    @Override
+    public boolean SERVER_IS_1_8_TO_1_15_2(Player player) {
+        return CommonBootstrap.evaluateMCVersion("<=", "1.15.2");
+    }
+}

--- a/src/main/java/com/bergerkiller/bukkit/coasters/VersioningVanilla.java
+++ b/src/main/java/com/bergerkiller/bukkit/coasters/VersioningVanilla.java
@@ -4,7 +4,7 @@ import org.bukkit.entity.Player;
 
 public class VersioningVanilla implements Versioning {
 
-    boolean is1_16_2, is_1_16_to_1_16_1, is1_8_to_1_15_2;
+    private boolean is1_16_2, is_1_16_to_1_16_1, is1_8_to_1_15_2;
 
     public VersioningVanilla() {
         is1_16_2 = CommonBootstrap.evaluateMCVersion(">=", "1.16.2");

--- a/src/main/java/com/bergerkiller/bukkit/coasters/VersioningVanilla.java
+++ b/src/main/java/com/bergerkiller/bukkit/coasters/VersioningVanilla.java
@@ -4,18 +4,26 @@ import org.bukkit.entity.Player;
 
 public class VersioningVanilla implements Versioning {
 
+    boolean is1_16_2, is_1_16_to_1_16_1, is1_8_to_1_15_2;
+
+    public VersioningVanilla() {
+        is1_16_2 = CommonBootstrap.evaluateMCVersion(">=", "1.16.2");
+        is_1_16_to_1_16_1 = CommonBootstrap.evaluateMCVersion("<=", "1.16.1") && CommonBootstrap.evaluateMCVersion(">=", "1.16");
+        is1_8_to_1_15_2 =  CommonBootstrap.evaluateMCVersion("<=", "1.15.2");
+    }
+
     @Override
     public boolean SERVER_IS_1_16_2(Player player) {
-        return CommonBootstrap.evaluateMCVersion(">=", "1.16.2");
+        return is1_16_2;
     }
 
     @Override
     public boolean SERVER_1_16_TO_1_16_1(Player player) {
-        return CommonBootstrap.evaluateMCVersion("<=", "1.16.1") && CommonBootstrap.evaluateMCVersion(">=", "1.16");
+        return is_1_16_to_1_16_1;
     }
 
     @Override
     public boolean SERVER_IS_1_8_TO_1_15_2(Player player) {
-        return CommonBootstrap.evaluateMCVersion("<=", "1.15.2");
+        return is1_8_to_1_15_2;
     }
 }

--- a/src/main/java/com/bergerkiller/bukkit/coasters/VersioningViaVersion.java
+++ b/src/main/java/com/bergerkiller/bukkit/coasters/VersioningViaVersion.java
@@ -1,0 +1,24 @@
+package com.bergerkiller.bukkit.coasters;
+import org.bukkit.entity.Player;
+import us.myles.ViaVersion.api.Via;
+import us.myles.ViaVersion.api.ViaAPI;
+
+public class VersioningViaVersion implements Versioning {
+
+    ViaAPI api = Via.getAPI();
+
+    @Override
+    public boolean SERVER_IS_1_16_2(Player player) {
+        return (api.getPlayerVersion(player) >= 751);
+    }
+
+    @Override
+    public boolean SERVER_1_16_TO_1_16_1(Player player) {
+        return (api.getPlayerVersion(player) >= 735 && api.getPlayerVersion(player) <= 736);
+    }
+
+    @Override
+    public boolean SERVER_IS_1_8_TO_1_15_2(Player player) {
+        return (api.getPlayerVersion(player) >= 47 && api.getPlayerVersion(player) <= 578);
+    }
+}

--- a/src/main/java/com/bergerkiller/bukkit/coasters/VersioningViaVersion.java
+++ b/src/main/java/com/bergerkiller/bukkit/coasters/VersioningViaVersion.java
@@ -14,11 +14,13 @@ public class VersioningViaVersion implements Versioning {
 
     @Override
     public boolean SERVER_1_16_TO_1_16_1(Player player) {
-        return (api.getPlayerVersion(player) >= 735 && api.getPlayerVersion(player) <= 736);
+        int version = api.getPlayerVersion(player);
+        return (version >= 735 && version <= 736);
     }
 
     @Override
     public boolean SERVER_IS_1_8_TO_1_15_2(Player player) {
-        return (api.getPlayerVersion(player) >= 47 && api.getPlayerVersion(player) <= 578);
+        int version = api.getPlayerVersion(player);
+        return (version >= 47 && version <= 578);
     }
 }

--- a/src/main/java/com/bergerkiller/bukkit/coasters/particles/TrackParticleLine.java
+++ b/src/main/java/com/bergerkiller/bukkit/coasters/particles/TrackParticleLine.java
@@ -55,11 +55,9 @@ public class TrackParticleLine extends TrackParticle {
         removePosition(this.p2);
     }
 
-    //TODO: Replace with active viaversion checks of the player itself
 
 
     private LineOffsets getOffsets(Player player) {
-        //TODO: Handle ViaVersion and retrieve the right offsets to use
         if (TCCoasters.getVersioning().SERVER_IS_1_16_2(player)) {
             return OFFSETS_1_16_2;
         } else if (TCCoasters.getVersioning().SERVER_1_16_TO_1_16_1(player)) {

--- a/src/main/java/com/bergerkiller/bukkit/coasters/particles/TrackParticleLine.java
+++ b/src/main/java/com/bergerkiller/bukkit/coasters/particles/TrackParticleLine.java
@@ -58,9 +58,9 @@ public class TrackParticleLine extends TrackParticle {
 
 
     private LineOffsets getOffsets(Player player) {
-        if (TCCoasters.getVersioning().SERVER_IS_1_16_2(player)) {
+        if (getWorld().getPlugin().getVersioning().SERVER_IS_1_16_2(player)) {
             return OFFSETS_1_16_2;
-        } else if (TCCoasters.getVersioning().SERVER_1_16_TO_1_16_1(player)) {
+        } else if (getWorld().getPlugin().getVersioning().SERVER_1_16_TO_1_16_1(player)) {
             return OFFSETS_1_16_TO_1_16_1;
         } else {
             return OFFSETS_1_8_TO_1_15_2;

--- a/src/main/java/com/bergerkiller/bukkit/coasters/particles/TrackParticleLine.java
+++ b/src/main/java/com/bergerkiller/bukkit/coasters/particles/TrackParticleLine.java
@@ -2,6 +2,7 @@ package com.bergerkiller.bukkit.coasters.particles;
 
 import java.util.UUID;
 
+import com.bergerkiller.bukkit.coasters.TCCoasters;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
@@ -55,15 +56,13 @@ public class TrackParticleLine extends TrackParticle {
     }
 
     //TODO: Replace with active viaversion checks of the player itself
-    private static final boolean SERVER_IS_1_16_2 = CommonBootstrap.evaluateMCVersion(">=", "1.16.2");
-    private static final boolean SERVER_IS_1_16_TO_1_16_1 = CommonBootstrap.evaluateMCVersion("<=", "1.16.1") && CommonBootstrap.evaluateMCVersion(">=", "1.16");
-    //private static final boolean SERVER_IS_1_8_TO_1_15_2 = CommonBootstrap.evaluateMCVersion("<=", "1.15.2");
+
 
     private LineOffsets getOffsets(Player player) {
         //TODO: Handle ViaVersion and retrieve the right offsets to use
-        if (SERVER_IS_1_16_2) {
+        if (TCCoasters.getVersioning().SERVER_IS_1_16_2(player)) {
             return OFFSETS_1_16_2;
-        } else if (SERVER_IS_1_16_TO_1_16_1) {
+        } else if (TCCoasters.getVersioning().SERVER_1_16_TO_1_16_1(player)) {
             return OFFSETS_1_16_TO_1_16_1;
         } else {
             return OFFSETS_1_8_TO_1_15_2;

--- a/src/main/java/plugin.yml
+++ b/src/main/java/plugin.yml
@@ -5,7 +5,7 @@ build: ${project.build.number}
 authors: [bergerkiller]
 description: Add-on for TrainCarts that adds free-form rollercoaster track
 depend: [Train_Carts]
-softdepend: [PlotSquared, LightAPI]
+softdepend: [PlotSquared, LightAPI, ViaVersion]
 dev-url: ${project.url}
 api-version: 1.13
 commands:


### PR DESCRIPTION
Did some writing that should display leashes with the proper offset if the server has ViaVersion enabled. If it does not, it basically runs the old code.

I definitely wrote it in a weird way, not sure exactly how you want the code to look, Willing to do some changes if necessary. Since I don't have access to the PlotSquared API, IntelliJ wouldn't let me compile it. In order to see if it works, someone who is able to check that may have to compile it.