### PR TITLE
Ensured that `/tcc lock` locks selected coasters and doesn't unlock them

### DIFF
--- a/src/main/java/com/bergerkiller/bukkit/coasters/commands/EditStateCommands.java
+++ b/src/main/java/com/bergerkiller/bukkit/coasters/commands/EditStateCommands.java
@@ -211,9 +211,9 @@ class EditStateCommands {
             sender.sendMessage(ChatColor.RED + "You do not have permission to unlock coasters");
         } else {
             for (TrackCoaster coaster : state.getEditedCoasters()) {
-                coaster.setLocked(false);
+                coaster.setLocked(true);
             }
-            sender.sendMessage(ChatColor.YELLOW + "Selected coasters have been " + ChatColor.GREEN + "UNLOCKED");
+            sender.sendMessage(ChatColor.YELLOW + "Selected coasters have been " + ChatColor.RED + "LOCKED");
         }
     }
 


### PR DESCRIPTION
Previously it looks like the method body was copied from `commandUnlock`