### PR TITLE
Allow the particle view range to be overwritten per-player

### DIFF
--- a/src/main/java/com/bergerkiller/bukkit/coasters/commands/EditStateCommands.java
+++ b/src/main/java/com/bergerkiller/bukkit/coasters/commands/EditStateCommands.java
@@ -518,4 +518,37 @@ class EditStateCommands {
             sender.sendMessage(ChatColor.YELLOW + "Right-click drag menu control is now " + ChatColor.RED + "DISABLED");
         }
     }
+
+    @CommandRequiresTCCPermission
+    @Command("option particleviewrange <range>")
+    @CommandDescription("Sets the particle view range for yourself")
+    public void commandOptionViewRange(
+            final PlayerEditState state,
+            final CommandSender sender,
+            final TCCoasters plugin,
+            final @Argument("range") double range
+    ) {
+        if (range < 0) {
+            sender.sendMessage(ChatColor.RED + "Particle view range must be greater than or equal to 0");
+            return;
+        }
+        double oldRange = state.getParticleViewRange();
+        state.setParticleViewRange(range);
+        sender.sendMessage(ChatColor.YELLOW + "Particle view range set to " + ChatColor.WHITE + range + 
+                           ChatColor.YELLOW + " (was " + ChatColor.WHITE + oldRange + ChatColor.YELLOW + ")");
+    }
+
+    @CommandRequiresTCCPermission
+    @Command("option particleviewrange reset")
+    @CommandDescription("Resets your particle view range to the default")
+    public void commandOptionViewRangeReset(
+            final PlayerEditState state,
+            final CommandSender sender,
+            final TCCoasters plugin
+    ) {
+        double oldRange = state.getParticleViewRange();
+        state.setParticleViewRange(plugin.getParticleViewRange());
+        sender.sendMessage(ChatColor.YELLOW + "Particle view range reset to default " + ChatColor.WHITE + plugin.getParticleViewRange() +
+                           ChatColor.YELLOW + " (was " + ChatColor.WHITE + oldRange + ChatColor.YELLOW + ")");
+    }
 }

--- a/src/main/java/com/bergerkiller/bukkit/coasters/commands/EditStateCommands.java
+++ b/src/main/java/com/bergerkiller/bukkit/coasters/commands/EditStateCommands.java
@@ -526,14 +526,14 @@ class EditStateCommands {
             final PlayerEditState state,
             final CommandSender sender,
             final TCCoasters plugin,
-            final @Argument("range") double range
+            final @Argument("range") int range
     ) {
         if (range < 0) {
             sender.sendMessage(ChatColor.RED + "Particle view range must be greater than or equal to 0");
             return;
         }
-        double oldRange = state.getParticleViewRange();
-        state.setParticleViewRange(range);
+        int oldRange = state.getParticleViewRange();
+        state.setParticleViewRangeOverride(range);
         sender.sendMessage(ChatColor.YELLOW + "Particle view range set to " + ChatColor.WHITE + range + 
                            ChatColor.YELLOW + " (was " + ChatColor.WHITE + oldRange + ChatColor.YELLOW + ")");
     }
@@ -546,8 +546,8 @@ class EditStateCommands {
             final CommandSender sender,
             final TCCoasters plugin
     ) {
-        double oldRange = state.getParticleViewRange();
-        state.setParticleViewRange(plugin.getParticleViewRange());
+        int oldRange = state.getParticleViewRange();
+        state.setParticleViewRangeOverride(null);
         sender.sendMessage(ChatColor.YELLOW + "Particle view range reset to default " + ChatColor.WHITE + plugin.getParticleViewRange() +
                            ChatColor.YELLOW + " (was " + ChatColor.WHITE + oldRange + ChatColor.YELLOW + ")");
     }

--- a/src/main/java/com/bergerkiller/bukkit/coasters/editor/PlayerEditState.java
+++ b/src/main/java/com/bergerkiller/bukkit/coasters/editor/PlayerEditState.java
@@ -1869,7 +1869,7 @@ public class PlayerEditState implements CoasterWorldComponent {
      * @return particle view range for this player
      */
     public int getParticleViewRange() {
-        return particleViewRangeOverride.isPresent() ? particleViewRangeOverride.get() : plugin.getParticleViewRange();
+        return particleViewRangeOverride.orElse(plugin.getParticleViewRange());
     }
 
     /**

--- a/src/main/java/com/bergerkiller/bukkit/coasters/editor/PlayerEditState.java
+++ b/src/main/java/com/bergerkiller/bukkit/coasters/editor/PlayerEditState.java
@@ -95,6 +95,7 @@ public class PlayerEditState implements CoasterWorldComponent {
     private BlockFace targetedBlockFace = BlockFace.UP;
     private String selectedAnimation = null;
     private HistoryChange draggingCreateNewNodeChange = null; // used when player left-clicks while dragging a node
+    private double particleViewRange = TCCoasters.DEFAULT_PARTICLE_VIEW_RANGE; // Default particle view range
 
     public PlayerEditState(TCCoasters plugin, Player player) {
         this.plugin = plugin;
@@ -104,6 +105,7 @@ public class PlayerEditState implements CoasterWorldComponent {
         this.clipboard = new PlayerEditClipboard(this);
         this.objectState = new ObjectEditState(this);
         this.signState = new SignEditState(this);
+        this.particleViewRange = plugin.getParticleViewRange();
     }
 
     /**
@@ -127,6 +129,7 @@ public class PlayerEditState implements CoasterWorldComponent {
 
             this.editMode = config.get("mode", PlayerEditMode.DISABLED);
             this.selectedAnimation = config.get("selectedAnimation", String.class, null);
+            this.particleViewRange = config.get("particleViewRange", plugin.getParticleViewRange());
             this.getObjects().load(config);
             this.editedNodes.clear();
             this.editedNodesByAnimationName.clear();
@@ -179,6 +182,7 @@ public class PlayerEditState implements CoasterWorldComponent {
         } else {
             config.set("selectedAnimation", this.selectedAnimation);
         }
+        config.set("particleViewRange", this.particleViewRange);
         this.getObjects().save(config);
         config.save();
     }
@@ -1856,6 +1860,30 @@ public class PlayerEditState implements CoasterWorldComponent {
      */
     private void removeConnectionForAnimationStates(TrackNode node, TrackNodeReference target) {
         node.removeAnimationStateConnection(this.selectedAnimation, target);
+    }
+
+    /**
+     * Gets the player-specific particle view range
+     * 
+     * @return particle view range for this player
+     */
+    public double getParticleViewRange() {
+        return this.particleViewRange;
+    }
+
+    /**
+     * Sets the player-specific particle view range
+     * 
+     * @param range particle view range to set
+     */
+    public void setParticleViewRange(double range) {
+        if (this.particleViewRange != range) {
+            this.particleViewRange = range;
+            this.markChanged();
+            
+            // Update particles for this player
+            getWorld().getParticles().scheduleViewerUpdate(this.player);
+        }
     }
 
     /**

--- a/src/main/java/com/bergerkiller/bukkit/coasters/particles/TrackParticleWorld.java
+++ b/src/main/java/com/bergerkiller/bukkit/coasters/particles/TrackParticleWorld.java
@@ -239,7 +239,10 @@ public class TrackParticleWorld implements CoasterWorldComponent {
             // This uses the octree to do so efficiently
             Integer updateObject = Integer.valueOf(this.updateCtr++);
             viewed.block = viewerBlock;
-            int cuboid_range = this.getPlugin().getParticleViewRange();
+            int cuboid_range = this.getPlugin().getEditState(viewer).getParticleViewRange();
+            if (cuboid_range < 0) {
+                cuboid_range = this.getPlugin().getParticleViewRange();
+            }
             int maxParticles = this.getPlugin().getMaximumParticleCount();
             IntVector3 range_min = viewerBlock.subtract(cuboid_range, cuboid_range, cuboid_range);
             IntVector3 range_max = viewerBlock.add(cuboid_range, cuboid_range, cuboid_range);

--- a/src/main/java/com/bergerkiller/bukkit/coasters/particles/TrackParticleWorld.java
+++ b/src/main/java/com/bergerkiller/bukkit/coasters/particles/TrackParticleWorld.java
@@ -240,9 +240,6 @@ public class TrackParticleWorld implements CoasterWorldComponent {
             Integer updateObject = Integer.valueOf(this.updateCtr++);
             viewed.block = viewerBlock;
             int cuboid_range = this.getPlugin().getEditState(viewer).getParticleViewRange();
-            if (cuboid_range < 0) {
-                cuboid_range = this.getPlugin().getParticleViewRange();
-            }
             int maxParticles = this.getPlugin().getMaximumParticleCount();
             IntVector3 range_min = viewerBlock.subtract(cuboid_range, cuboid_range, cuboid_range);
             IntVector3 range_max = viewerBlock.add(cuboid_range, cuboid_range, cuboid_range);


### PR DESCRIPTION
Currently, `particleViewRange` is a global config value. This PR extends it to be configurable per-player.

Two edit state commands have been added:
`/tcc option particleviewrange <range>`: sets the player's particle view range to the specified value
`/tcc option particleviewrange reset`: resets the player's particle view range to the globally configured value